### PR TITLE
Fix raspimjpg linked wrong.

### DIFF
--- a/RPi_Cam_Web_Interface_Installer.sh
+++ b/RPi_Cam_Web_Interface_Installer.sh
@@ -161,8 +161,8 @@ case "$1" in
         sudo chmod 755 /opt/vc/bin/raspimjpeg
         sudo cp -r www/* /var/www/$rpicamdir/
 
-        if [ ! -e /var/www/raspimjpeg ]; then
-          sudo ln -s /etc/raspimjpeg /var/www/raspimjpeg
+        if [ ! -e /var/www/$rpicamdir/raspimjpeg ]; then
+          sudo ln -s /etc/raspimjpeg /var/www/$rpicamdir/raspimjpeg
         fi
         sudo chmod 755 /var/www/$rpicamdir/raspizip.sh
 


### PR DESCRIPTION
If subdirectory used then raspimjpg linked wrong place if update. linked in www root not in subdirectory.