### PR TITLE
Fix when /etc/raspimjpeg not exist.

### DIFF
--- a/RPi_Cam_Web_Interface_Installer.sh
+++ b/RPi_Cam_Web_Interface_Installer.sh
@@ -133,6 +133,10 @@ case "$1" in
         else
           sed -e "s/www/www\/$rpicamdir/" etc/raspimjpeg/raspimjpeg.1 > etc/raspimjpeg/raspimjpeg
         fi
+        if [ -e /etc/raspimjpeg ]; then
+          echo "Your custom raspimjpg backed up at /etc/raspimjpeg.bak"
+          sudo cp -r /etc/raspimjpeg /etc/raspimjpeg.bak
+        fi
         sudo cp -r /etc/raspimjpeg /etc/raspimjpeg.bak
         sudo cp -r etc/raspimjpeg/raspimjpeg /etc/
         sudo chmod 644 /etc/raspimjpeg


### PR DESCRIPTION
We make backup when /etc/raspimjpeg already in place and not generate error output. We notify users we made backup.