### PR TITLE
Fix rc.local

### DIFF
--- a/etc/rc_local_run/rc.local.1
+++ b/etc/rc_local_run/rc.local.1
@@ -15,12 +15,11 @@ fi
 mkdir -p /dev/shm/mjpeg
 chown www-data:www-data /dev/shm/mjpeg
 chmod 777 /dev/shm/mjpeg
+sleep 4;su -c 'raspimjpeg > /dev/null 2>&1 &' www-data
 if [ -e /etc/debian_version ]; then
-  sleep 4;su -c 'raspimjpeg > /dev/null 2>&1 &' www-data
-  sleep 4;su -c 'php /var/www/schedule.php > /dev/null  2>&1 &' www-data
+  sleep 4;su -c "php /var/www/schedule.php > /dev/null 2>&1 &" www-data
 else
-  sleep 4;su -c 'raspimjpeg > /dev/null  2>&1 &' www-data
-  sleep 4;su -s '/bin/bash' -c "php /var/www/schedule.php > /dev/null  2>&1 &" www-data
+  sleep 4;su -s '/bin/bash' -c "php /var/www/schedule.php > /dev/null 2>&1 &" www-data
 fi
 #END RASPIMJPEG SECTION
 


### PR DESCRIPTION
roberttidey Please look differences in rc.local and main installer script start option. Why needed to look if /etc/debian_version is exists? Distributions differences i think. We need improve start option also in that case.