### PR TITLE
Improvement remove option

### DIFF
--- a/RPi_Cam_Web_Interface_Installer.sh
+++ b/RPi_Cam_Web_Interface_Installer.sh
@@ -336,15 +336,24 @@ case "$1" in
 
   remove)
         sudo killall raspimjpeg
-        package=('apache2' 'php5' 'libapache2-mod-php5' 'zip' 'nginx' 'php5-fpm' 'php5-common' 'php-apc' 'gpac motion'); 
-        for i in "${package[@]}"
-         do
-           if [ $(dpkg-query -W -f='${Status}' "$i" 2>/dev/null | grep -c "ok installed") -eq 1 ];
-           then
-             sudo apt-get remove -y "$i"
-           fi
-         done
-        sudo apt-get autoremove -y
+        tmp_message="Do yow want uninstall webserver and php packages also?"
+	fn_tmp_yes ()
+	{
+          package=('apache2' 'php5' 'libapache2-mod-php5' 'zip' 'nginx' 'php5-fpm' 'php5-common' 'php-apc' 'gpac motion'); 
+          for i in "${package[@]}"
+           do
+             if [ $(dpkg-query -W -f='${Status}' "$i" 2>/dev/null | grep -c "ok installed") -eq 1 ];
+             then
+               sudo apt-get remove -y "$i"
+             fi
+           done
+          sudo apt-get autoremove -y
+	}
+	fn_tmp_no ()
+	{
+		echo ""
+	}
+	fn_yesno
 
         fn_rpicamdir
         sudo rm -r /var/www/$rpicamdir/*


### PR DESCRIPTION
We ask users what they want todo with webserver and php. We cant expect users using only rpicam alone! Maby they no want uninstall webserver himself...
What we do with webroot? I personally think we mast set it /var/www/ and leave it there. In forum i read people not like webroot set in subfolder and they cant use more websites in different subfolders.
Is that makes problems in PHP programming side if we deside abadon weebroot set into subfolder?
roberttidey you are agee with me? If you agree i programming installer that way.