### PR TITLE
Fix remove option

### DIFF
--- a/RPi_Cam_Web_Interface_Installer.sh
+++ b/RPi_Cam_Web_Interface_Installer.sh
@@ -356,7 +356,12 @@ case "$1" in
 	fn_yesno
 
         fn_rpicamdir
-        sudo rm -r /var/www/$rpicamdir/*
+	if [ ! "$rpicamdir" == "" ]; then
+	  sudo rm -r /var/www/$rpicamdir
+	else
+	  # Here needed think. If rpicamdir not set then removed all webserver content!
+	  sudo rm -r /var/www/*
+	fi
         sudo rm /etc/sudoers.d/RPI_Cam_Web_Interface
         sudo rm /usr/bin/raspimjpeg
         sudo rm /etc/raspimjpeg


### PR DESCRIPTION
I see here problem. I suggest use always default subfolder when installing. If we but all files in /var/www then in remove time all destroyd!
But if users have there more stuff!? Then they not happy i think.
I leaved in code notice about that issue.
# Here needed think. If rpicamdir not set then removed all webserver content!