### PR TITLE
Fix remove not need ask rpmcamdir

### DIFF
--- a/RPi_Cam_Web_Interface_Installer.sh
+++ b/RPi_Cam_Web_Interface_Installer.sh
@@ -400,7 +400,6 @@ case "$1" in
 	}
 	fn_yesno
 
-        fn_rpicamdir
 	if [ ! "$rpicamdir" == "" ]; then
 	  sudo rm -r /var/www/$rpicamdir
 	else


### PR DESCRIPTION
I think if we remove then not needed distrub users and ask where rpmcamdir is. We take it ./config.txt and use that.