### PR TITLE
Fix "versionfile"

### DIFF
--- a/RPi_Cam_Web_Interface_Installer.sh
+++ b/RPi_Cam_Web_Interface_Installer.sh
@@ -468,12 +468,7 @@ esac
 
 fn_menu_installer ()
 {
-if [ "$rpicamdir" == "" ]; then
-  versionfile="/var/www/config.php"
-else
-  versionfile="/var/www/$rpicamdir/config.php"
-fi
-
+versionfile="./www/config.php"
 version=$(cat $versionfile | grep "'APP_VERSION'" | cut -d "'" -f4)
 backtitle="Copyright (c) 2014, Silvan Melchior. RPi Cam $version"
 


### PR DESCRIPTION
If Rpicam not already installed we cant search "version" from installed testination! We use source config.php insted.
That way we no get version what already installed but we get installer version what also not wrong. I think its bether, because athervice user think hi have old version installer... That way we can move combo:

versionfile="./www/config.php"
version=$(cat $versionfile | grep "'APP_VERSION'" | cut -d "'" -f4)
backtitle="Copyright (c) 2014, Silvan Melchior. RPi Cam $version"

also in top if we want or needed.