### PR TITLE
Security fix: Prevent download of any file on filesystem

### DIFF
--- a/www/download.php
+++ b/www/download.php
@@ -2,7 +2,7 @@
 
   if(substr($_GET["file"], -3) == "jpg") header("Content-Type: image/jpeg");
   else header("Content-Type: video/mp4");
-  header("Content-Disposition: attachment; filename=\"" . $_GET["file"] . "\"");
-  readfile("media/" . $_GET["file"]);
+  header("Content-Disposition: attachment; filename=\"" . basename($_GET["file"]) . "\"");
+  readfile("media/" . basename($_GET["file"]));
 
 ?>


### PR DESCRIPTION
download.php trusts the user provided filename with no sanitisation. This allows for a gaping security hole - download.php can be used to download any file on the filesystem by requesting a path such as `download.php?file=../config.php` for example. This can be done by anyone who stumbles across this running on a Pi - no authentication system has been implemented, after all.

This pull request aims to strip paths from the user-supplied filename.