### PR TITLE
Wrong status of scheduler start/stop button

### DIFF
--- a/www/schedule.php
+++ b/www/schedule.php
@@ -125,7 +125,7 @@
 
    function getSchedulePID() {
       $pids = array();
-      exec("ps -ef | awk '$9==\"schedule.php\" {print $2}'", $pids);
+      exec("ps -ef | awk '$9==\"/var/www/schedule.php\" {print $2}'", $pids);
       $pidId = 0;
       if (count($pids) > 0) {
          if (is_numeric($pids[0])) {


### PR DESCRIPTION
On Pi reboot/start the scheduler start/stop button status doesn't show the correct state, because of the wrong process string. If you press then "Start" on the sheduler page again, the schedule process is running twice, which leads to a weird behavior of the scheduler.

Signed-off-by: hasenbolle <edgi@arcor.de>