### PR TITLE
Improving loading of previews and keyboard navigation

### DIFF
--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -1,0 +1,54 @@
+/*global thumbnails,previewWidth,linksBase,mediaBase*/
+function load_preview(thumbnail) {
+	var prevButton = document.getElementsByName('prev')[0];
+	var nextButton = document.getElementsByName('next')[0];
+	var mediaDiv = document.getElementById('media');
+	var imageIndex = thumbnails.indexOf(thumbnail);
+	var prev, next;
+	if (imageIndex > 0) {
+		prev = thumbnails[imageIndex-1];
+	}
+	if (imageIndex >= 0 && imageIndex < thumbnails.length-1) {
+		next = thumbnails[imageIndex+1];
+	}
+
+	if (prev) {
+		prevButton.disabled = false;
+		prevButton.onclick = function() {
+			load_preview(prev);
+		}
+	} else {
+		prevButton.disabled = true;
+	}
+
+	if (next) {
+		nextButton.disabled = false;
+		nextButton.onclick = function() {
+			load_preview(next);
+		}
+	} else {
+		nextButton.disabled = true;
+	}
+
+	var mediaURL = mediaBase + imageFromThumbnail(thumbnail);
+	if (mediaURL) {
+		var media_content;
+		if (fileExtension(mediaURL) == 'jpg') {
+			var linkURL = linksBase + thumbnail;
+			media_content = '<a href="' + linkURL + '" target="_blank"><img src="' + mediaURL + '" style="width: ' + previewWidth + 'px;"></a>';
+		} else {
+			media_content = '<video style="width:' + previewWidth + '"px;" controls><source src="' + mediaURL + '" type="video/mp4">Your browser does not support the video tag.</video>';
+		}
+
+		mediaDiv.innerHTML = media_content;
+	}
+}
+
+function imageFromThumbnail(thumbnailName) {
+	var suffix = '.v0000.th.jpg';
+	return thumbnailName.substr(0, thumbnailName.length - suffix.length);
+}
+
+function fileExtension(fileName) {
+	return fileName.split('.').pop();
+}

--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -1,10 +1,16 @@
 /*global thumbnails,previewWidth,linksBase,mediaBase*/
+var thumbinailSuffix = '.v0000.th.jpg';
+
 function load_preview(thumbnail) {
 	var prevButton = document.getElementsByName('prev')[0];
 	var nextButton = document.getElementsByName('next')[0];
 	var mediaDiv = document.getElementById('media');
-	var imageIndex = thumbnails.indexOf(thumbnail);
+	var title = document.getElementById('media-title');
+
+	title.innerHTML = fileTitle(thumbnail);
+
 	var prev, next;
+	var imageIndex = thumbnails.indexOf(thumbnail);
 	if (imageIndex > 0) {
 		prev = thumbnails[imageIndex-1];
 	}
@@ -34,8 +40,7 @@ function load_preview(thumbnail) {
 	if (mediaURL) {
 		var media_content;
 		if (fileExtension(mediaURL) == 'jpg') {
-			var linkURL = linksBase + thumbnail;
-			media_content = '<a href="' + linkURL + '" target="_blank"><img src="' + mediaURL + '" style="width: ' + previewWidth + 'px;"></a>';
+			media_content = '<a href="' + mediaURL + '" target="_blank"><img src="' + mediaURL + '" style="width: ' + previewWidth + 'px;"></a>';
 		} else {
 			media_content = '<video style="width:' + previewWidth + '"px;" controls><source src="' + mediaURL + '" type="video/mp4">Your browser does not support the video tag.</video>';
 		}
@@ -45,10 +50,13 @@ function load_preview(thumbnail) {
 }
 
 function imageFromThumbnail(thumbnailName) {
-	var suffix = '.v0000.th.jpg';
-	return thumbnailName.substr(0, thumbnailName.length - suffix.length);
+	return thumbnailName.substr(0, thumbnailName.length - thumbinailSuffix.length);
 }
 
 function fileExtension(fileName) {
 	return fileName.split('.').pop();
+}
+
+function fileTitle(thumbnailName) {
+	return thumbnailName.substr(thumbnailName.length - thumbinailSuffix.length + 1).substr(0, thumbinailSuffix.length - 8);
 }

--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -41,6 +41,7 @@ function load_preview(thumbnail) {
 	// Previous 
 	if (imageIndex > 0) {
 		prev = thumbnails[imageIndex-1];
+		preloadImage(mediaBase + imageFromThumbnail(prev));
 		prevButton.disabled = false;
 		prevButton.onclick = function() {
 			load_preview(prev);
@@ -53,6 +54,7 @@ function load_preview(thumbnail) {
 	// Next
 	if (imageIndex >= 0 && imageIndex < thumbnails.length-1) {
 		next = thumbnails[imageIndex+1];
+		preloadImage(mediaBase + imageFromThumbnail(next));
 		nextButton.disabled = false;
 		nextButton.onclick = function() {
 			load_preview(next);
@@ -100,6 +102,11 @@ function fileType(fileName) {
 
 function fileTitle(thumbnailName) {
 	return thumbnailName.substr(thumbnailName.length - thumbinailSuffix.length + 1).substr(0, thumbinailSuffix.length - 8);
+}
+
+function preloadImage(url) {
+    var _img = new Image();
+    _img.src = url;
 }
 
 function getParameterByName(name, url) {

--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -1,7 +1,7 @@
-/*global thumbnails,previewWidth,linksBase,mediaBase*/
-var thumbinailSuffix = '.v0000.th.jpg';
+var thumbinailSuffix = '.v0000.th.jpg'; // Sample suffix
 
 function load_preview(thumbnail) {
+	var previewDiv = document.getElementById('preview');
 	var prevButton = document.getElementsByName('prev')[0];
 	var nextButton = document.getElementsByName('next')[0];
 	var downloadButton = document.getElementsByName('download1')[0];
@@ -11,6 +11,8 @@ function load_preview(thumbnail) {
 	var mediaDiv = document.getElementById('media');
 	var title = document.getElementById('media-title');
 
+	previewDiv.style.display = 'block';
+	history.pushState(null, null, linksBase + thumbnail);
 
 	title.innerHTML = fileTitle(thumbnail);
 	downloadButton.value = thumbnail;
@@ -23,7 +25,6 @@ function load_preview(thumbnail) {
 		var prev = thumbnails[imageIndex-1];
 		prevButton.disabled = false;
 		prevButton.onclick = function() {
-			history.pushState(null, null, linksBase + prev);
 			load_preview(prev);
 		}
 	} else {
@@ -35,7 +36,6 @@ function load_preview(thumbnail) {
 		var next = thumbnails[imageIndex+1];
 		nextButton.disabled = false;
 		nextButton.onclick = function() {
-			history.pushState(null, null, linksBase + next);
 			load_preview(next);
 		}
 	} else {
@@ -80,4 +80,14 @@ function fileType(fileName) {
 
 function fileTitle(thumbnailName) {
 	return thumbnailName.substr(thumbnailName.length - thumbinailSuffix.length + 1).substr(0, thumbinailSuffix.length - 8);
+}
+
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
 }

--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -41,10 +41,13 @@ function load_preview(thumbnail) {
 	// Previous 
 	if (imageIndex > 0) {
 		prev = thumbnails[imageIndex-1];
-		preloadImage(mediaBase + imageFromThumbnail(prev));
 		prevButton.disabled = false;
 		prevButton.onclick = function() {
 			load_preview(prev);
+		}
+
+		if (fileExtension(imageFromThumbnail(prev)) == 'jpg') {
+			preloadImage(mediaBase + imageFromThumbnail(prev));
 		}
 	} else {
 		prev = null;
@@ -54,10 +57,13 @@ function load_preview(thumbnail) {
 	// Next
 	if (imageIndex >= 0 && imageIndex < thumbnails.length-1) {
 		next = thumbnails[imageIndex+1];
-		preloadImage(mediaBase + imageFromThumbnail(next));
 		nextButton.disabled = false;
 		nextButton.onclick = function() {
 			load_preview(next);
+		}
+
+		if (fileExtension(imageFromThumbnail(next)) == 'jpg') {
+			preloadImage(mediaBase + imageFromThumbnail(next));
 		}
 	} else {
 		next = null;

--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -1,4 +1,22 @@
 var thumbinailSuffix = '.v0000.th.jpg'; // Sample suffix
+var next, prev;
+
+(function() {
+	document.onkeyup = function () {
+		switch (event.keyCode) {
+		case 39:
+		    if (next) {
+		    	load_preview(next);
+		    }
+		    break;
+		case 37:
+		    if (prev) {
+		    	load_preview(prev);
+		    }
+		    break;
+		}
+	};
+})();
 
 function load_preview(thumbnail) {
 	var previewDiv = document.getElementById('preview');
@@ -22,23 +40,25 @@ function load_preview(thumbnail) {
 
 	// Previous 
 	if (imageIndex > 0) {
-		var prev = thumbnails[imageIndex-1];
+		prev = thumbnails[imageIndex-1];
 		prevButton.disabled = false;
 		prevButton.onclick = function() {
 			load_preview(prev);
 		}
 	} else {
+		prev = null;
 		prevButton.disabled = true;
 	}
 
 	// Next
 	if (imageIndex >= 0 && imageIndex < thumbnails.length-1) {
-		var next = thumbnails[imageIndex+1];
+		next = thumbnails[imageIndex+1];
 		nextButton.disabled = false;
 		nextButton.onclick = function() {
 			load_preview(next);
 		}
 	} else {
+		next = null;
 		nextButton.disabled = true;
 	}
 

--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -4,10 +4,17 @@ var thumbinailSuffix = '.v0000.th.jpg';
 function load_preview(thumbnail) {
 	var prevButton = document.getElementsByName('prev')[0];
 	var nextButton = document.getElementsByName('next')[0];
+	var downloadButton = document.getElementsByName('download1')[0];
+	var deleteButton = document.getElementsByName('delete1')[0];
+	var convertDetailsDiv = document.getElementById('convert-details');
+	var convertButton = document.getElementsByName('convert')[0];
 	var mediaDiv = document.getElementById('media');
 	var title = document.getElementById('media-title');
 
+
 	title.innerHTML = fileTitle(thumbnail);
+	downloadButton.value = thumbnail;
+	deleteButton.value = thumbnail;
 
 	var imageIndex = thumbnails.indexOf(thumbnail);
 
@@ -46,6 +53,16 @@ function load_preview(thumbnail) {
 
 		mediaDiv.innerHTML = media_content;
 	}
+
+	if (fileType(thumbnail) == 't') {
+		convertDetailsDiv.style.display = 'inline';
+		convertButton.style.display = 'inline';
+		convertButton.value = thumbnail;
+	} else {
+		convertDetailsDiv.style.display = 'none';
+		convertButton.style.display = 'none';
+		convertButton.value = '';
+	}
 }
 
 function imageFromThumbnail(thumbnailName) {
@@ -54,6 +71,11 @@ function imageFromThumbnail(thumbnailName) {
 
 function fileExtension(fileName) {
 	return fileName.split('.').pop();
+}
+
+function fileType(fileName) {
+	var suffix = fileName.substr(-thumbinailSuffix.length);
+	return suffix.substr(1, 1);
 }
 
 function fileTitle(thumbnailName) {

--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -9,27 +9,26 @@ function load_preview(thumbnail) {
 
 	title.innerHTML = fileTitle(thumbnail);
 
-	var prev, next;
 	var imageIndex = thumbnails.indexOf(thumbnail);
-	if (imageIndex > 0) {
-		prev = thumbnails[imageIndex-1];
-	}
-	if (imageIndex >= 0 && imageIndex < thumbnails.length-1) {
-		next = thumbnails[imageIndex+1];
-	}
 
-	if (prev) {
+	// Previous 
+	if (imageIndex > 0) {
+		var prev = thumbnails[imageIndex-1];
 		prevButton.disabled = false;
 		prevButton.onclick = function() {
+			history.pushState(null, null, linksBase + prev);
 			load_preview(prev);
 		}
 	} else {
 		prevButton.disabled = true;
 	}
 
-	if (next) {
+	// Next
+	if (imageIndex >= 0 && imageIndex < thumbnails.length-1) {
+		var next = thumbnails[imageIndex+1];
 		nextButton.disabled = false;
 		nextButton.onclick = function() {
+			history.pushState(null, null, linksBase + next);
 			load_preview(next);
 		}
 	} else {

--- a/www/preview.php
+++ b/www/preview.php
@@ -265,7 +265,7 @@
       echo "</legend>";
       if ($fsz > 0) echo "$fsz Kb $lapseCount $duration"; else echo 'Busy';
       echo "<br>$fDate<br>$fTime<br>";
-      if ($fsz > 0) echo "<a title='$rFile' href='preview.php?preview=$f'>";
+      if ($fsz > 0) echo "<a title='$rFile' href='javascript:load_preview(\"$f\");'>";
       echo "<img src='" . MEDIA_PATH . "/$f' style='width:" . $ts . "px'/>";
       if ($fsz > 0) echo "</a>";
       echo "</fieldset> ";
@@ -373,6 +373,14 @@
       <script src="js/style_minified.js"></script>
       <script src="js/script.js"></script>
       <script src="js/preview.js"></script>
+      <script>
+         var thumbnails = <?php echo json_encode($thumbnails) ?>;
+         var linksBase = 'preview.php?preview=';
+         var mediaBase = "<?php echo MEDIA_PATH . '/' ?>";
+         var previewWidth = <?php echo $previewSize ?>;
+         var convertCmd = "<?php echo file_get_contents(BASE_DIR . '/' . CONVERT_CMD) ?>";
+      </script>
+
    </head>
    <body>
       <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -387,39 +395,32 @@
     
       <div class="container-fluid">
       <form action="preview.php" method="POST">
-      <?php
-         if ($pFile != "") {
-      ?>
-         <h1>
-            <?php echo TXT_PREVIEW ?>: <span id='media-title'></span>
-            <input type='button' value='&larr;' class='btn btn-primary' name='prev'>
-            <input type='button' value='&rarr;' class='btn btn-primary' name='next'>
+         <div id='preview' style="display: none;">
+            <h1>
+               <?php echo TXT_PREVIEW ?>: <span id='media-title'></span>
+               <input type='button' value='&larr;' class='btn btn-primary' name='prev'>
+               <input type='button' value='&rarr;' class='btn btn-primary' name='next'>
 
-            <button class='btn btn-primary' type='submit' name='download1'><?php echo BTN_DOWNLOAD; ?></button>
-            <button class='btn btn-danger' type='submit' name='delete1'><?php echo BTN_DELETE; ?></button>
-            
-            <button class='btn btn-primary' type='submit' name='convert'><?php echo BTN_CONVERT ?></button>
-            <br>
-         </h1>
+               <button class='btn btn-primary' type='submit' name='download1'><?php echo BTN_DOWNLOAD; ?></button>
+               <button class='btn btn-danger' type='submit' name='delete1'><?php echo BTN_DELETE; ?></button>
+               
+               <button class='btn btn-primary' type='submit' name='convert'><?php echo BTN_CONVERT ?></button>
+               <br>
+            </h1>
 
-         <div id="convert-details">
-            Convert using: <input type='text' size=72 name = 'convertCmd' id='convertCmd' value='<?php echo $convertCmd ?>'><br><br>
+            <div id="convert-details">
+               Convert using: <input type='text' size=72 name = 'convertCmd' id='convertCmd' value='<?php echo $convertCmd ?>'><br><br>
+            </div>
+
+            <div id='media'></div>
          </div>
 
-         <div id='media'></div>
          <script>
-            var thumbnails = <?php echo json_encode($thumbnails) ?>;
-            var linksBase = 'preview.php?preview=';
-            var mediaBase = "<?php echo MEDIA_PATH . '/' ?>";
-            var previewWidth = <?php echo $previewSize ?>;
-            var convertCmd = "<?php echo file_get_contents(BASE_DIR . '/' . CONVERT_CMD) ?>";
-
-            load_preview("<?php echo $tFile; ?>");
+            var thumbnail = getParameterByName('preview');
+            if (thumbnail) {
+               load_preview(thumbnail);
+            }
          </script>
-
-      <?php 
-         } 
-      ?>
 
          <h1><?php echo TXT_FILES; ?>
          <button class='btn btn-primary' type='submit' name='action' value='selectNone'><?php echo BTN_SELECTNONE; ?></button>

--- a/www/preview.php
+++ b/www/preview.php
@@ -265,7 +265,7 @@
       echo "</legend>";
       if ($fsz > 0) echo "$fsz Kb $lapseCount $duration"; else echo 'Busy';
       echo "<br>$fDate<br>$fTime<br>";
-      if ($fsz > 0) echo "<a title='$rFile' href='javascript:load_preview(\"$f\");'>";
+      if ($fsz > 0) echo "<a title='$rFile' href='#' onclick='load_preview(\"$f\");'>";
       echo "<img src='" . MEDIA_PATH . "/$f' style='width:" . $ts . "px'/>";
       if ($fsz > 0) echo "</a>";
       echo "</fieldset> ";

--- a/www/preview.php
+++ b/www/preview.php
@@ -370,6 +370,7 @@
       <link rel="stylesheet" href="<?php echo getStyle(); ?>" />
       <script src="js/style_minified.js"></script>
       <script src="js/script.js"></script>
+      <script src="js/preview.js"></script>
    </head>
    <body>
       <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -384,43 +385,73 @@
     
       <div class="container-fluid">
       <form action="preview.php" method="POST">
+      <h1><?php echo TXT_PREVIEW . ":  " . getFileType($tFile) . getFileIndex($tFile) ?>
       <?php
          $thumbnails = getThumbnails();
          if ($pFile != "") {
             $pIndex = array_search($tFile, $thumbnails);
-            echo "<h1>" . TXT_PREVIEW . ":  " . getFileType($tFile) . getFileIndex($tFile);
-            if ($pIndex > 0)
-               $attr = 'onclick="location.href=\'preview.php?preview=' . $thumbnails[$pIndex-1] . '\'"';
-            else
-               $attr = 'disabled';
-            echo "&nbsp;&nbsp;<input type='button' value='&larr;' class='btn btn-primary' name='prev' $attr >";
-            if (($pIndex+1) < count($thumbnails))
-               $attr = 'onclick="location.href=\'preview.php?preview=' . $thumbnails[$pIndex+1] . '\'"';
-            else
-               $attr = 'disabled';
-            echo "&nbsp;&nbsp;<input type='button' value='&rarr;' class='btn btn-primary' name='next' $attr>";
-            echo "&nbsp;&nbsp;<button class='btn btn-primary' type='submit' name='download1' value='$tFile'>" . BTN_DOWNLOAD . "</button>";
-            echo "&nbsp;<button class='btn btn-danger' type='submit' name='delete1' value='$tFile'>" . BTN_DELETE . "</button>";
+            $media_url = MEDIA_PATH . "/" . $pFile;
+            $link_url = MEDIA_PATH . "/" . $tFile;
+            $nav_links_base = 'preview.php?preview=';
+
+            if ($pIndex > 0) {
+               $prev = $thumbnails[$pIndex-1];
+            } else {
+               $prev = NULL;
+            }
+
+            if (($pIndex+1) < count($thumbnails)) {
+               $next = $thumbnails[$pIndex+1];
+            }
+            else {
+               $next = NULL;
+            }
+
             if(getFileType($tFile) == "t") {
                $convertCmd = file_get_contents(BASE_DIR . '/' . CONVERT_CMD);
-               echo "&nbsp;<button class='btn btn-primary' type='submit' name='convert' value='$tFile'>" . BTN_CONVERT . "</button>";
-               echo "<br></h1>Convert using: <input type='text' size=72 name = 'convertCmd' id='convertCmd' value='$convertCmd'><br><br>";
             } else {
-               echo "<br></h1>";
+               $convertCmd = NULL;
             }
-            if(substr($pFile, -3) == "jpg") {
-               echo "<a href='" . MEDIA_PATH . "/$tFile' target='_blank'><img src='" . MEDIA_PATH . "/$pFile' width='" . $previewSize . "px'></a>";
-            } else {
-               echo "<video width='" . $previewSize . "px' controls><source src='" . MEDIA_PATH . "/$pFile' type='video/mp4'>Your browser does not support the video tag.</video>";
+
+      ?>
+            <input type='button' value='&larr;' class='btn btn-primary' name='prev'>
+            <input type='button' value='&rarr;' class='btn btn-primary' name='next'>
+
+            <button class='btn btn-primary' type='submit' name='download1' value='$tFile'><?php echo BTN_DOWNLOAD; ?></button>
+            <button class='btn btn-danger' type='submit' name='delete1' value='$tFile'><?php echo BTN_DELETE; ?></button>
+            
+            <br></h1>
+
+      <?php
+            if(getFileType($tFile) == "t") {
+               $convertCmd = file_get_contents(BASE_DIR . '/' . CONVERT_CMD);
+               echo "<button class='btn btn-primary' type='submit' name='convert' value='$tFile'>" . BTN_CONVERT . "</button>";
+               echo "Convert using: <input type='text' size=72 name = 'convertCmd' id='convertCmd' value='$convertCmd'><br><br>";
             }
-         }
-         echo "<h1>" . TXT_FILES . "&nbsp;&nbsp;";
-         echo "&nbsp;&nbsp;<button class='btn btn-primary' type='submit' name='action' value='selectNone'>" . BTN_SELECTNONE . "</button>";
-         echo "&nbsp;&nbsp;<button class='btn btn-primary' type='submit' name='action' value='selectAll'>" . BTN_SELECTALL . "</button>";
-         echo "&nbsp;&nbsp;<button class='btn btn-primary' type='submit' name='action' value='zipSel'>" . BTN_GETZIP . "</button>";
-         echo "&nbsp;&nbsp;<button class='btn btn-danger' type='submit' name='action' value='deleteSel' onclick=\"return confirm('Are you sure?');\">" . BTN_DELETESEL . "</button>";
-         echo "&nbsp;&nbsp;<button class='btn btn-danger' type='submit' name='action' value='deleteAll' onclick=\"return confirm('Are you sure?');\">" . BTN_DELETEALL . "</button>";
-         echo "</h1>";
+
+      ?>
+         <div id='media'></div>
+         <script>
+            var thumbnails = <?php echo json_encode($thumbnails); ?>;
+            var linksBase = "<?php echo $nav_links_base; ?>";
+            var mediaBase = "<?php echo MEDIA_PATH . '/'; ?>";
+            var previewWidth = <?php echo $previewSize; ?>;
+
+            load_preview("<?php echo $tFile; ?>");
+         </script>
+
+      <?php 
+         } 
+      ?>
+
+         <h1><?php echo TXT_FILES; ?>
+         <button class='btn btn-primary' type='submit' name='action' value='selectNone'><?php echo BTN_SELECTNONE; ?></button>
+         <button class='btn btn-primary' type='submit' name='action' value='selectAll'><?php echo BTN_SELECTALL; ?></button>
+         <button class='btn btn-primary' type='submit' name='action' value='zipSel'><?php echo BTN_GETZIP; ?></button>
+         <button class='btn btn-danger' type='submit' name='action' value='deleteSel' onclick="return confirm('Are you sure?');"><?php echo BTN_DELETESEL; ?></button>
+         <button class='btn btn-danger' type='submit' name='action' value='deleteAll' onclick="return confirm('Are you sure?');"><?php echo BTN_DELETEALL; ?></button>
+         </h1>
+         <?php
          diskUsage();
          if(CONTROLS_POS == 'top') settingsControls();
          if ($debugString !="") echo "$debugString<br>";

--- a/www/preview.php
+++ b/www/preview.php
@@ -395,7 +395,7 @@
     
       <div class="container-fluid">
       <form action="preview.php" method="POST">
-         <div id='preview' style="display: none;">
+         <div id='preview' style="display: none; min-height: <?php echo $previewSize ?>px">
             <h1>
                <?php echo TXT_PREVIEW ?>: <span id='media-title'></span>
                <input type='button' value='&larr;' class='btn btn-primary' name='prev'>

--- a/www/preview.php
+++ b/www/preview.php
@@ -359,6 +359,8 @@
       echo "&nbsp;<button class='btn btn-primary' type='submit' name='action' value='updateSizeOrder'>" . BTN_UPDATESIZEORDER . "</button><br>";
    }
    
+   $convertCmd = file_get_contents(BASE_DIR . '/' . CONVERT_CMD);
+   $thumbnails = getThumbnails();
 ?>
 <!DOCTYPE html>
 <html>
@@ -385,40 +387,32 @@
     
       <div class="container-fluid">
       <form action="preview.php" method="POST">
-      <h1><?php echo TXT_PREVIEW ?>: <span id='media-title'></span>
       <?php
-         $thumbnails = getThumbnails();
          if ($pFile != "") {
- 
-            if(getFileType($tFile) == "t") {
-               $convertCmd = file_get_contents(BASE_DIR . '/' . CONVERT_CMD);
-            } else {
-               $convertCmd = NULL;
-            }
-
       ?>
+         <h1>
+            <?php echo TXT_PREVIEW ?>: <span id='media-title'></span>
             <input type='button' value='&larr;' class='btn btn-primary' name='prev'>
             <input type='button' value='&rarr;' class='btn btn-primary' name='next'>
 
-            <button class='btn btn-primary' type='submit' name='download1' value='$tFile'><?php echo BTN_DOWNLOAD; ?></button>
-            <button class='btn btn-danger' type='submit' name='delete1' value='$tFile'><?php echo BTN_DELETE; ?></button>
+            <button class='btn btn-primary' type='submit' name='download1'><?php echo BTN_DOWNLOAD; ?></button>
+            <button class='btn btn-danger' type='submit' name='delete1'><?php echo BTN_DELETE; ?></button>
             
-            <br></h1>
+            <button class='btn btn-primary' type='submit' name='convert'><?php echo BTN_CONVERT ?></button>
+            <br>
+         </h1>
 
-      <?php
-            if(getFileType($tFile) == "t") {
-               $convertCmd = file_get_contents(BASE_DIR . '/' . CONVERT_CMD);
-               echo "<button class='btn btn-primary' type='submit' name='convert' value='$tFile'>" . BTN_CONVERT . "</button>";
-               echo "Convert using: <input type='text' size=72 name = 'convertCmd' id='convertCmd' value='$convertCmd'><br><br>";
-            }
+         <div id="convert-details">
+            Convert using: <input type='text' size=72 name = 'convertCmd' id='convertCmd' value='<?php echo $convertCmd ?>'><br><br>
+         </div>
 
-      ?>
          <div id='media'></div>
          <script>
-            var thumbnails = <?php echo json_encode($thumbnails); ?>;
+            var thumbnails = <?php echo json_encode($thumbnails) ?>;
             var linksBase = 'preview.php?preview=';
-            var mediaBase = "<?php echo MEDIA_PATH . '/'; ?>";
-            var previewWidth = <?php echo $previewSize; ?>;
+            var mediaBase = "<?php echo MEDIA_PATH . '/' ?>";
+            var previewWidth = <?php echo $previewSize ?>;
+            var convertCmd = "<?php echo file_get_contents(BASE_DIR . '/' . CONVERT_CMD) ?>";
 
             load_preview("<?php echo $tFile; ?>");
          </script>

--- a/www/preview.php
+++ b/www/preview.php
@@ -385,28 +385,11 @@
     
       <div class="container-fluid">
       <form action="preview.php" method="POST">
-      <h1><?php echo TXT_PREVIEW . ":  " . getFileType($tFile) . getFileIndex($tFile) ?>
+      <h1><?php echo TXT_PREVIEW ?>: <span id='media-title'></span>
       <?php
          $thumbnails = getThumbnails();
          if ($pFile != "") {
-            $pIndex = array_search($tFile, $thumbnails);
-            $media_url = MEDIA_PATH . "/" . $pFile;
-            $link_url = MEDIA_PATH . "/" . $tFile;
-            $nav_links_base = 'preview.php?preview=';
-
-            if ($pIndex > 0) {
-               $prev = $thumbnails[$pIndex-1];
-            } else {
-               $prev = NULL;
-            }
-
-            if (($pIndex+1) < count($thumbnails)) {
-               $next = $thumbnails[$pIndex+1];
-            }
-            else {
-               $next = NULL;
-            }
-
+ 
             if(getFileType($tFile) == "t") {
                $convertCmd = file_get_contents(BASE_DIR . '/' . CONVERT_CMD);
             } else {
@@ -433,7 +416,7 @@
          <div id='media'></div>
          <script>
             var thumbnails = <?php echo json_encode($thumbnails); ?>;
-            var linksBase = "<?php echo $nav_links_base; ?>";
+            var linksBase = 'preview.php?preview=';
             var mediaBase = "<?php echo MEDIA_PATH . '/'; ?>";
             var previewWidth = <?php echo $previewSize; ?>;
 


### PR DESCRIPTION
Hey! 

I’ve been using this software for a long time and having to reload the entire page when navigating through the previews was something that really annoyed me.

I’ve refactored the preview.php code that handles the media to load it dynamically using JavaScript, so that:

- Loading a different preview does not reload the entire page - only the preview div
- The browsing history/URL remains valid
- You can navigate through the files using the arrow keys (left/right)
- The previous and next images are preloaded so that the navigation looks smoother

As a bonus, the HTML part from preview.php is a lot more readable now :)

I hope I got everything ok - it seems to be working well here (although I wasn’t able to test videos and tl a lot).