### PR TITLE
Fix path status_mjpeg.txt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -340,7 +340,7 @@ if [ ! -e /run/shm/mjpeg/status_mjpeg.txt ]; then
    echo -n 'halted' > /run/shm/mjpeg/status_mjpeg.txt
 fi
 sudo chown www-data:www-data /run/shm/mjpeg/status_mjpeg.txt
-sudo ln -sf /run/shm/mjpeg/status_mjpeg.txt /var/www$rpicamdir/status_mjpeg.txt
+sudo ln -sf /dev/shm/mjpeg/status_mjpeg.txt /var/www$rpicamdir/status_mjpeg.txt
 
 sudo chown -R www-data:www-data /var/www$rpicamdir
 sudo cp etc/sudoers.d/RPI_Cam_Web_Interface /etc/sudoers.d/


### PR DESCRIPTION
I had to replace the link in the installer, because at this location there was no file. Did anyone else experience this? But i think this is not the perfect solution. Could you help me with this. The installer says this status file does not exist.
