### PR TITLE
make dualstack listen by default

### DIFF
--- a/etc/nginx/sites-available/rpicam.1
+++ b/etc/nginx/sites-available/rpicam.1
@@ -1,5 +1,5 @@
 server {
-	listen   80;
+	listen   [::]:80;
 
 	root /var/www;
 	index index.php index.html index.htm;


### PR DESCRIPTION
This makes nginx listen on IPv4 and IPv6.
It has been tested even with net.ipv6.conf.all.disable_ipv6=1 and it works.