### PR TITLE
added lazy loading for preview images

### DIFF
--- a/www/preview.php
+++ b/www/preview.php
@@ -374,7 +374,14 @@
          var previewWidth = <?php echo $previewSize ?>;
          var convertCmd = "<?php $f = fopen(BASE_DIR . '/' . CONVERT_CMD, 'r');echo trim(fgets($f));fclose($f); ?>";
       </script>
-
+      <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+      <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.6/jquery.lazy.min.js"></script>
+      <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.6/jquery.lazy.plugins.min.js"></script>
+      <script>
+        $(function() {
+          $('.lazy').Lazy();
+        });
+      </script>
    </head>
    <body>
       <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">


### PR DESCRIPTION
Hi,

my browser was sometimes freezing when looking at preview page while having too many thumbnails to show. I've added the first jquery lazy loading plugin that I've found on google.

Take a look if you like it. For me it works better now since I can directly scroll to the "time" where I want to see images.