### PR TITLE
Ras07 Delete Selected / Delete All buttons

### DIFF
--- a/www/macros/startstopX.sh
+++ b/www/macros/startstopX.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # example start up script which converts any existing .h264 files into MP4
-#Check if script already running
-mypidfile=/var/www/html/macros/startstopX.sh.pid
 
+MACRODIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BASEDIR="$( cd "$( dirname "${MACRODIR}" )" >/dev/null 2>&1 && pwd )"
+mypidfile=${MACRODIR}/startstop.sh.pid
+mylogfile=${BASEDIR}/scheduleLog.txt
+
+#Check if script already running
 NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
 if [ -f $mypidfile ]; then
-        echo "${NOW} Script already running..." >> /var/www/html/scheduleLog.txt
+        echo "${NOW} Script already running..." >> ${mylogfile}
         exit
 fi
 #Remove PID file when exiting
@@ -15,22 +19,22 @@ echo $$ > "$mypidfile"
 
 #Do conversion
 if [ "$1" == "start" ]; then
-  cd $(dirname $(readlink -f $0))
+  cd ${MACRODIR}
   cd ../media
   shopt -s nullglob
   for f in *.h264
     do
-      f1=${f%.*}
+      f1=${f%.*}.mp4
         NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-        echo "${NOW} Converting $f" >> /var/www/html/scheduleLog.txt
+        echo "${NOW} Converting $f" >> ${mylogfile}
         #set -e;MP4Box -fps 25 -add $f $f1 > /dev/null 2>&1;rm $f;
         if MP4Box -fps 25 -add $f $f1; then
                 NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-                echo "${NOW} Conversion complete, removing $f" >> /var/www/html/scheduleLog.txt
+                echo "${NOW} Conversion complete, removing $f" >> ${mylogfile}
                 rm $f
         else
                 NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-                echo "${NOW} Error with $f" >> /var/www/html/scheduleLog.txt
+                echo "${NOW} Error with $f" >> ${mylogfile}
         fi
     done
 fi

--- a/www/preview.php
+++ b/www/preview.php
@@ -100,7 +100,7 @@
       //global commands
       switch($_POST['action']) {
          case 'deleteAll':
-            maintainFolders(MEDIA_PATH, true, true);
+            maintainFolders(MEDIA_PATH, true, false);
             break;
          case 'selectAll':
             $dSelect = "checked";

--- a/www/preview.php
+++ b/www/preview.php
@@ -489,7 +489,7 @@ function diskUsage() {
          <button class='btn btn-primary' type='submit' name='action' value='selectNone'><?php echo BTN_SELECTNONE; ?></button>
          <button class='btn btn-primary' type='submit' name='action' value='selectAll'><?php echo BTN_SELECTALL; ?></button>
          <button class='btn btn-primary' type='submit' name='action' value='zipSel'><?php echo BTN_GETZIP; ?></button>
-         <button class='btn btn-danger' type='submit' name='action' value='deleteSel' onclick="return confirm('<?php echo BTN_DELETESEL_CONFIRM; ?>')"><?php echo BTN_DELETESEL; ?></button>
+         <button class='btn btn-warning' type='submit' name='action' value='deleteSel' onclick="return confirm('<?php echo BTN_DELETESEL_CONFIRM; ?>')"><?php echo BTN_DELETESEL; ?></button>
          <button class='btn btn-danger' type='submit' name='action' value='deleteAll' onclick="return confirm('<?php echo BTN_DELETEALL_CONFIRM; ?>')"><?php echo BTN_DELETEALL; ?></button>
          <button class='btn btn-primary' type='submit' name='action' value='lockSel'><?php echo BTN_LOCKSEL; ?></button>
          <button class='btn btn-primary' type='submit' name='action' value='unlockSel'><?php echo BTN_UNLOCKSEL; ?></button>


### PR DESCRIPTION
The Delete All button wipes out not only all files in the media directory but also all subdirectories recursively, which I think is unexpected behavior (at least to me). Normally the media directory doesn't have any subdirectories; if it does, they're probably there intentionally (I was using a subdirectory to archive clips I wanted to save, but they kept disappearing).

Also, it's easy to hit the "Delete All" button when you mean to hit "Delete Selected" instead. Making the buttons different colors would help prevent this. There aren't any other yellow buttons on this page, so using yellow for "Delete Selected" seems like an adequate warning.

(These are each literally one-word changes)