### PR TITLE
Update startstopX.sh

### DIFF
--- a/www/macros/startstopX.sh
+++ b/www/macros/startstopX.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # example start up script which converts any existing .h264 files into MP4
-#Check if script already running
-mypidfile=/var/www/html/macros/startstopX.sh.pid
 
+MACRODIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BASEDIR="$( cd "$( dirname "${MACRODIR}" )" >/dev/null 2>&1 && pwd )"
+mypidfile=${MACRODIR}/startstop.sh.pid
+mylogfile=${BASEDIR}/scheduleLog.txt
+
+#Check if script already running
 NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
 if [ -f $mypidfile ]; then
-        echo "${NOW} Script already running..." >> /var/www/html/scheduleLog.txt
+        echo "${NOW} Script already running..." >> ${mylogfile}
         exit
 fi
 #Remove PID file when exiting
@@ -15,22 +19,22 @@ echo $$ > "$mypidfile"
 
 #Do conversion
 if [ "$1" == "start" ]; then
-  cd $(dirname $(readlink -f $0))
+  cd ${MACRODIR}
   cd ../media
   shopt -s nullglob
   for f in *.h264
     do
-      f1=${f%.*}
+      f1=${f%.*}.mp4
         NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-        echo "${NOW} Converting $f" >> /var/www/html/scheduleLog.txt
+        echo "${NOW} Converting $f" >> ${mylogfile}
         #set -e;MP4Box -fps 25 -add $f $f1 > /dev/null 2>&1;rm $f;
         if MP4Box -fps 25 -add $f $f1; then
                 NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-                echo "${NOW} Conversion complete, removing $f" >> /var/www/html/scheduleLog.txt
+                echo "${NOW} Conversion complete, removing $f" >> ${mylogfile}
                 rm $f
         else
                 NOW=`date +"-%Y/%m/%d %H:%M:%S-"`
-                echo "${NOW} Error with $f" >> /var/www/html/scheduleLog.txt
+                echo "${NOW} Error with $f" >> ${mylogfile}
         fi
     done
 fi


### PR DESCRIPTION
This script was missing the .mp4 extension for the output files (boxed files had no extension at all). In addition it didn't work if the code was installed somewhere other than /var/www/html. This corrects both those problems.

However, this script might be obsolete regardless; in my experience it seems like orphaned .h264 files automatically get converted after a restart anyway, even without enabling this script. (I haven't tested that theory extensively though.)

If there are cases where this script is still needed, these changes should make it more useful. If not, perhaps this file should just be deleted from the distribution.