### PR TITLE
set panel content background also dark

### DIFF
--- a/www/css/es_Night.css
+++ b/www/css/es_Night.css
@@ -14,6 +14,19 @@ body {
 	color: #C0C0C0;
 }
 
+.panel-collapse {
+    background-color: #202020;
+    color: #C0C0C0;
+}
+.settingsTable input{
+    background-color: #202020;
+    color: #C0C0C0;
+}
+.settingsTable select{
+    background-color: #202020;
+    color: #C0C0C0;
+}
+
 fieldset {
    color:#808080;
 }


### PR DESCRIPTION
extended the night mode so that the content of the panels also follows the dark mode.

old:
![old](https://user-images.githubusercontent.com/90598549/152676697-e5037a68-dce3-4e46-99f8-d6745830b154.png)

new:
![new](https://user-images.githubusercontent.com/90598549/152676700-35bc3b22-c77b-4e08-9020-d2b33286c12a.png)
