### PR TITLE
Add support for Bookworm with new `rpicam-mjpeg` backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ etc/nginx/sites-available/default
 # settings
 etc/raspimjpeg/raspimjpeg
 bin/work
+bin/raspimjpeg.bak

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ etc/nginx/sites-available/default
 
 # settings
 etc/raspimjpeg/raspimjpeg
+bin/work

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Installation
 
 ### Step 1: Install dependencies + [rpicam-mjpeg](https://github.com/consiliumsolutions/p05a-rpicam-apps)
 ```bash
+git clone git@github.com:consiliumsolutions/RPi_Cam_Web_Interface.git
 cd RPi_Cam_Web_Interface
 bin/install-rpicam-mjpeg.sh
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+Installation
+-----
+
+### Step 1: Install dependencies + [rpicam-mjpeg](https://github.com/consiliumsolutions/p05a-rpicam-apps)
+```bash
+cd RPi_Cam_Web_Interface
+bin/install-rpicam-mjpeg.sh
+```
+
+### Step 2: Install the web application
+```bash
+./install.sh
+```
+
+### Step 3: Run the web application + rpicam-mjpeg
+```bash
+./start.sh
+```
+NOTE: When you run this command, you may encounter error: `bash: line 1: /usr/bin/raspimjpeg: cannot execute: required file not found`, this is due to historical reasons, which can be safely ignored.
+
+Finally, visit our program at: http://localhost/html/ and start using it!
+
+-----
+
 Web based interface for controlling the Raspberry Pi Camera, includes motion detection, time lapse, and image and video recording.
 Current version 6.6.26
 All information on this project can be found here: http://www.raspberrypi.org/forums/viewtopic.php?f=43&t=63276

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ bin/install-rpicam-mjpeg.sh
 ```bash
 ./start.sh
 ```
-NOTE: When you run this command, you may encounter error: `bash: line 1: /usr/bin/raspimjpeg: cannot execute: required file not found`, this is due to historical reasons, which can be safely ignored.
-
-Finally, visit our program at: http://localhost/html/ and start using it!
+Now, visit our program at: http://localhost/html/ and start using it!
 
 -----
 

--- a/bin/install-rpicam-mjpeg.sh
+++ b/bin/install-rpicam-mjpeg.sh
@@ -19,18 +19,19 @@ install_libcamera() {
         libglib2.0-dev libgstreamer-plugins-base1.0-dev
 
     meson setup build --buildtype=release -Dpipelines=rpi/vc4,rpi/pisp -Dipas=rpi/vc4,rpi/pisp -Dv4l2=true -Dgstreamer=enabled -Dtest=false -Dlc-compliance=disabled -Dcam=disabled -Dqcam=disabled -Ddocumentation=disabled -Dpycamera=enabled
-    ninja -C build install
+    sudo ninja -C build install
 
     cd ..
 }
 
 # Compile and install rpicam-mjpeg from source
+
 install_rpicam_mjpeg() {
     set -e
     git clone "$RPICAM_APPS_REMOTE" rpicam-apps
     cd rpicam-apps
 
-    sudo apt install -y cmake libboost-program-options-dev libdrm-dev libexif-dev libavdevice-dev \
+    sudo apt install -y cmake libboost-program-options-dev libdrm-dev libexif-dev libavdevice-dev libpng-dev libepoxy-dev\
         meson ninja-build
 
     meson setup build -Denable_libav=enabled -Denable_drm=enabled -Denable_egl=enabled -Denable_qt=enabled -Denable_opencv=disabled -Denable_tflite=disabled
@@ -47,7 +48,7 @@ fi
 mkdir ./work
 pushd ./work
 
-# install_libcamera
+install_libcamera
 install_rpicam_mjpeg
 
 popd

--- a/bin/install-rpicam-mjpeg.sh
+++ b/bin/install-rpicam-mjpeg.sh
@@ -2,7 +2,7 @@
 set -e
 
 LIBCAMERA_REMOTE=https://github.com/raspberrypi/libcamera.git
-RPICAM_APPS_REMOTE=git@github.com:consiliumsolutions/p05a-rpicam-apps.git
+RPICAM_APPS_REMOTE=https://github.com/Windermere-Technology/rpicam-mjpeg.git
 
 # Compile and install libcamera from source
 install_libcamera() {

--- a/bin/install-rpicam-mjpeg.sh
+++ b/bin/install-rpicam-mjpeg.sh
@@ -36,7 +36,7 @@ install_rpicam_mjpeg() {
 
     meson setup build -Denable_libav=enabled -Denable_drm=enabled -Denable_egl=enabled -Denable_qt=enabled -Denable_opencv=disabled -Denable_tflite=disabled
     meson compile -C build
-    sudo meson install -C build --destdir=/usr/local
+    sudo meson install -C build
 
     cd ..
 }
@@ -58,4 +58,4 @@ if [ -e ./raspimjpeg ]; then
     mv ./raspimjpeg ./raspimjpeg.bak
 fi
 
-ln -s /usr/local/bin/rpicam-mjpeg ./raspimjpeg
+ln -s `which rpicam-mjpeg` ./raspimjpeg

--- a/bin/install-rpicam-mjpeg.sh
+++ b/bin/install-rpicam-mjpeg.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+LIBCAMERA_REMOTE=https://github.com/raspberrypi/libcamera.git
+RPICAM_APPS_REMOTE=git@github.com:consiliumsolutions/p05a-rpicam-apps.git
+
+# Compile and install libcamera from source
+install_libcamera() {
+    set -e
+    git clone "$LIBCAMERA_REMOTE" libcamera
+    cd libcamera
+
+    sudo apt install -y python3-pip git python3-jinja2 \
+        libboost-dev \
+        libgnutls28-dev openssl libtiff-dev pybind11-dev \
+        qtbase5-dev libqt5core5a libqt5widgets5 \
+        meson cmake \
+        python3-yaml python3-ply \
+        libglib2.0-dev libgstreamer-plugins-base1.0-dev
+
+    meson setup build --buildtype=release -Dpipelines=rpi/vc4,rpi/pisp -Dipas=rpi/vc4,rpi/pisp -Dv4l2=true -Dgstreamer=enabled -Dtest=false -Dlc-compliance=disabled -Dcam=disabled -Dqcam=disabled -Ddocumentation=disabled -Dpycamera=enabled
+    ninja -C build install
+
+    cd ..
+}
+
+# Compile and install rpicam-mjpeg from source
+install_rpicam_mjpeg() {
+    set -e
+    git clone "$RPICAM_APPS_REMOTE" rpicam-apps
+    cd rpicam-apps
+
+    sudo apt install -y cmake libboost-program-options-dev libdrm-dev libexif-dev libavdevice-dev \
+        meson ninja-build
+
+    meson setup build -Denable_libav=enabled -Denable_drm=enabled -Denable_egl=enabled -Denable_qt=enabled -Denable_opencv=disabled -Denable_tflite=disabled
+    meson compile -C build
+    sudo meson install -C build --destdir=/usr/local
+
+    cd ..
+}
+
+if [ -d ./work ]; then
+    rm -rf work
+fi
+
+mkdir ./work
+pushd ./work
+
+# install_libcamera
+install_rpicam_mjpeg
+
+popd
+
+# Create a symlink for install.sh to install
+if [ -e ./raspimjpeg ]; then
+    mv ./raspimjpeg ./raspimjpeg.bak
+fi
+
+ln -s /usr/local/bin/rpicam-mjpeg ./raspimjpeg

--- a/install.sh
+++ b/install.sh
@@ -157,6 +157,32 @@ else
    rpicamdirEsc=""
 fi
 
+install_gpac()
+{
+    # if gpac is already installed, do nothing
+    if `command -v gpac >/dev/null`; then
+        return
+    fi
+
+    # install via apt if available
+    if `sudo apt install -y gpac`; then
+        return
+    fi
+
+    # build from source
+    work=$(mktemp -d)
+    pushd $work
+
+    sudo apt install build-essential pkg-config g++ git cmake yasm
+    git clone https://github.com/gpac/gpac.git gpac
+    cd gpac
+    ./configure
+    make
+    sudo make install
+
+    popd
+}
+
 fn_stop ()
 { # This is function stop
         sudo killall raspimjpeg 2>/dev/null
@@ -373,16 +399,19 @@ else
    phpv=php$phpversion
 fi
 
+install_gpac
+if [ $? -ne 0 ]; then exit; fi
+
 if [ "$webserver" == "apache" ]; then
-   sudo apt-get install -y apache2 $phpv $phpv-cli libapache2-mod-$phpv gpac motion zip gstreamer1.0-tools
+   sudo apt-get install -y apache2 $phpv $phpv-cli libapache2-mod-$phpv motion zip gstreamer1.0-tools
    if [ $? -ne 0 ]; then exit; fi
    fn_apache
 elif [ "$webserver" == "nginx" ]; then
-   sudo apt-get install -y nginx $phpv-fpm $phpv-cli $phpv-common php-apcu apache2-utils gpac motion zip gstreamer1.0-tools
+   sudo apt-get install -y nginx $phpv-fpm $phpv-cli $phpv-common php-apcu apache2-utils motion zip gstreamer1.0-tools
    if [ $? -ne 0 ]; then exit; fi
    fn_nginx
 elif [ "$webserver" == "lighttpd" ]; then
-   sudo apt-get install -y  lighttpd $phpv-cli $phpv-common $phpv-cgi $phpv gpac motion zip gstreamer1.0-tools
+   sudo apt-get install -y  lighttpd $phpv-cli $phpv-common $phpv-cgi $phpv motion zip gstreamer1.0-tools
    if [ $? -ne 0 ]; then exit; fi
    fn_lighttpd
 fi


### PR DESCRIPTION
The `rpicam-mjpeg` program is based off of the [rpicam-apps](https://github.com/raspberrypi/rpicam-apps) project. It is designed as a replacement for the `RaspiMJPEG` program, which cannot be used on Bookworm due to the removal of MMAL APIs.

The project is still a WIP, with some more major bugs/issues highlighted in the Github issues, however it is functional as a proof of concept/starting point for switching to `libcamera`, supporting the preview stream, still image and motion detection functions.

To use the new program, run the `./bin/install-rpicam-mjpeg.sh` script, which will
* Install `rpicam-mjpeg` to the system
* Create a symlink `./bin/raspimjpeg` pointing to the `rpicam-mjpeg` program

Now the `./install.sh` script can be run to install the web interface itself, and it will run `rpicam-mjpeg` by default (ie. when using start automatically, or `./start.sh`).

The public source for `rpicam-mjpeg` is located: https://github.com/Windermere-Technology/rpicam-mjpeg

The project was completed as a part of university project, as discussed in #688, with contributions from @Yucheng-Yan, @ning-bao, @Pzhang768, @SheXinLim, @ching-cheng-lu, @Dinnicus, @Baiken1412, and mentorship from @wallarug 😊